### PR TITLE
FIX: Refactor & adjustments for better functionality

### DIFF
--- a/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
+++ b/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
@@ -213,6 +213,7 @@ Have you selected two different themes for your dark/light schemes in user prefe
 
         click() {
           toggleDarkLight();
+          this.scheduleRerender();
         },
 
         html() {
@@ -251,6 +252,7 @@ Have you selected two different themes for your dark/light schemes in user prefe
           } else {
             switchToAuto();
           }
+          this.scheduleRerender();
         },
 
         html() {

--- a/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
+++ b/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
@@ -70,7 +70,7 @@ Have you selected two different themes for your dark/light schemes in user prefe
       lightTheme.media = "none";
 
       Session.currentProp("defaultColorSchemeIsDark", true);
-      Session.currentProp("darkModeAvailable", true)
+      Session.currentProp("darkModeAvailable", true);
     };
 
     let switchToLight = function () {
@@ -82,7 +82,7 @@ Have you selected two different themes for your dark/light schemes in user prefe
       darkTheme.media = "none";
 
       Session.currentProp("defaultColorSchemeIsDark", false);
-      Session.currentProp("darkModeAvailable", false)
+      Session.currentProp("darkModeAvailable", false);
     };
 
     let switchToAuto = function () {
@@ -95,10 +95,10 @@ Have you selected two different themes for your dark/light schemes in user prefe
 
       if (window?.matchMedia("(prefers-color-scheme: dark)").matches) {
         Session.currentProp("defaultColorSchemeIsDark", true);
-        Session.currentProp("darkModeAvailable", true)
+        Session.currentProp("darkModeAvailable", true);
       } else {
         Session.currentProp("defaultColorSchemeIsDark", false);
-        Session.currentProp("darkModeAvailable", false)
+        Session.currentProp("darkModeAvailable", false);
       }
     };
 

--- a/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
+++ b/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
@@ -70,6 +70,7 @@ Have you selected two different themes for your dark/light schemes in user prefe
       lightTheme.media = "none";
 
       Session.currentProp("defaultColorSchemeIsDark", true);
+      Session.currentProp("darkModeAvailable", true)
     };
 
     let switchToLight = function () {
@@ -81,6 +82,7 @@ Have you selected two different themes for your dark/light schemes in user prefe
       darkTheme.media = "none";
 
       Session.currentProp("defaultColorSchemeIsDark", false);
+      Session.currentProp("darkModeAvailable", false)
     };
 
     let switchToAuto = function () {
@@ -93,8 +95,10 @@ Have you selected two different themes for your dark/light schemes in user prefe
 
       if (window?.matchMedia("(prefers-color-scheme: dark)").matches) {
         Session.currentProp("defaultColorSchemeIsDark", true);
+        Session.currentProp("darkModeAvailable", true)
       } else {
         Session.currentProp("defaultColorSchemeIsDark", false);
+        Session.currentProp("darkModeAvailable", false)
       }
     };
 
@@ -198,7 +202,9 @@ Have you selected two different themes for your dark/light schemes in user prefe
         },
       });
 
-      if (settings.add_color_scheme_toggle_to_header) {
+      // with new sidebar rolling out, this will be the main option of showing
+      // allow those who dont use sidebar to remove from header
+      if (!settings.remove_color_scheme_toggle_from_header) {
         api.addToHeaderIcons("dark-light-toggle");
       }
 

--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,7 @@ svg_icons:
   default: "moon|sun"
   type: "list"
   list_type: "compact"
-add_color_scheme_toggle_to_header:
+remove_color_scheme_toggle_from_header:
   default: false
   type: bool
-  description: "Add color scheme toggle button to site header"
+  description: "Do not show color scheme toggle button in site header"

--- a/settings.yml
+++ b/settings.yml
@@ -3,6 +3,6 @@ svg_icons:
   type: "list"
   list_type: "compact"
 remove_color_scheme_toggle_from_header:
-  default: false
+  default: true
   type: bool
   description: "Do not show color scheme toggle button in site header"


### PR DESCRIPTION
When users who had their system set to dark mode used the `toggle light scheme`, the logo would remain as a dark-mode logo. This has now been fixed.

I made the toggle appearing in the header the default in addition to appearing in the hamburger menu. I also changed the setting wording to "remove" the toggle from the header should an admin decide to do so.