### PR TITLE
FIX: Add ability for category logos to switch

### DIFF
--- a/javascripts/discourse/initializers/color-scheme-toggler.js
+++ b/javascripts/discourse/initializers/color-scheme-toggler.js
@@ -21,13 +21,6 @@ export default {
     const keyValueStore = container.lookup("service:key-value-store");
     const storedOverride = keyValueStore.getItem(COLOR_SCHEME_OVERRIDE_KEY);
 
-    if (Session.currentProp("darkModeAvailable") && storedOverride) {
-      schedule("afterRender", () => {
-        // delay needed for logo override
-        colorSchemeOverride(storedOverride);
-      });
-    }
-
     window
       .matchMedia("(prefers-color-scheme: dark)")
       .addEventListener("change", () => {
@@ -39,6 +32,14 @@ export default {
     if (settings.add_color_scheme_toggle_to_header) {
       withPluginApi("0.8", (api) => {
         api.addToHeaderIcons("header-toggle-button");
+        api.onPageChange(() => {
+          if (Session.currentProp("darkModeAvailable") && storedOverride) {
+            schedule("afterRender", () => {
+              // delay needed for logo override
+              colorSchemeOverride(storedOverride);
+            });
+          }
+        });
       });
     }
   },

--- a/javascripts/discourse/lib/color-scheme-override.js
+++ b/javascripts/discourse/lib/color-scheme-override.js
@@ -65,7 +65,9 @@ export function colorSchemeOverride(type) {
       if (categoryLogosDarkSrc) {
         for (let index = 0; index < categoryLogosDarkSrc.length; index++) {
           let logo = categoryLogosDarkSrc[index];
-          if (logo?.origMedia) logo.media = logo.origMedia;
+          if (logo?.origMedia) { 
+            logo.media = logo.origMedia;
+          }
         }
       }
       break;

--- a/javascripts/discourse/lib/color-scheme-override.js
+++ b/javascripts/discourse/lib/color-scheme-override.js
@@ -9,6 +9,9 @@ export function colorSchemeOverride(type) {
   }
 
   const logoDarkSrc = document.querySelector(".title picture source");
+  const categoryLogosDarkSrc = document.querySelectorAll(
+    ".category-logo picture source"
+  );
 
   switch (type) {
     case "dark":
@@ -20,6 +23,14 @@ export function colorSchemeOverride(type) {
         logoDarkSrc.origMedia = logoDarkSrc.media;
         logoDarkSrc.media = "all";
       }
+
+      if (categoryLogosDarkSrc) {
+        for (let index = 0; index < categoryLogosDarkSrc.length; index++) {
+          let logo = categoryLogosDarkSrc[index];
+          logo.origMedia = logo.media;
+          logo.media = "all";
+        }
+      }
       break;
     case "light":
       lightScheme.origMedia = lightScheme.media;
@@ -29,6 +40,14 @@ export function colorSchemeOverride(type) {
       if (logoDarkSrc) {
         logoDarkSrc.origMedia = logoDarkSrc.media;
         logoDarkSrc.media = "none";
+      }
+
+      if (categoryLogosDarkSrc) {
+        for (let index = 0; index < categoryLogosDarkSrc.length; index++) {
+          let logo = categoryLogosDarkSrc[index];
+          logo.origMedia = logo.media;
+          logo.media = "none";
+        }
       }
       break;
     default:
@@ -42,6 +61,12 @@ export function colorSchemeOverride(type) {
       }
       if (logoDarkSrc?.origMedia) {
         logoDarkSrc.media = logoDarkSrc.origMedia;
+      }
+      if (categoryLogosDarkSrc) {
+        for (let index = 0; index < categoryLogosDarkSrc.length; index++) {
+          let logo = categoryLogosDarkSrc[index];
+          if (logo?.origMedia) logo.media = logo.origMedia;
+        }
       }
       break;
   }


### PR DESCRIPTION
This addition allows all category logos to change from light to dark when toggling the color scheme.

### After
![Kapture 2022-12-14 at 17 05 37](https://user-images.githubusercontent.com/30537603/207734484-2f5f4e03-1ccf-416f-b5f0-6fdb769bfaf9.gif)

### Before
![Kapture 2022-12-14 at 17 06 52](https://user-images.githubusercontent.com/30537603/207734629-426881f3-5983-4a29-bccc-b1050181e8ef.gif)
