### PR TITLE
Deprecate discourse-color-scheme-toggle in favor of the core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# discourse-color-scheme-toggle
+# DEPRECATED
 
-Color Scheme Toggler to switch between Dark / Light schemes set by the user's preferences
-
-This component adds a clickable toggle color scheme button in the hamburger menu.
+This feature has been folded into Discourse core under the `interface color selector` site setting.

--- a/javascripts/discourse/connectors/home-logo-contents__after/minimized-hook.gjs
+++ b/javascripts/discourse/connectors/home-logo-contents__after/minimized-hook.gjs
@@ -8,6 +8,11 @@ import {
 } from "../../lib/color-scheme-override";
 
 export default class MinimizedHook extends Component {
+  static shouldRender(args, helper) {
+    const coreSelector = helper.siteSettings.interface_color_selector;
+    return coreSelector === undefined || coreSelector === "disabled";
+  }
+
   @service keyValueStore;
 
   @action

--- a/javascripts/discourse/connectors/sidebar-footer-actions/toggler-button.gjs
+++ b/javascripts/discourse/connectors/sidebar-footer-actions/toggler-button.gjs
@@ -3,6 +3,11 @@ import { service } from "@ember/service";
 import ColorSchemeToggler from "../../components/color-scheme-toggler";
 
 export default class TogglerButton extends Component {
+  static shouldRender(args, helper) {
+    const coreSelector = helper.siteSettings.interface_color_selector;
+    return coreSelector === undefined || coreSelector === "disabled";
+  }
+
   @service session;
   @service siteSettings;
 


### PR DESCRIPTION
This theme component has been folded into Discourse core in https://github.com/discourse/discourse/pull/31086. This PR makes the component a no-op if the core version is enabled and shows a warning message to inform admins to remove the component.